### PR TITLE
Fix bug introduced on refactor using list()

### DIFF
--- a/inc/class-cookies.php
+++ b/inc/class-cookies.php
@@ -113,7 +113,7 @@ class Cookies extends Plugin {
 	/*
 	 * Action: successful cookie login
 	 *
-	 * Clear any stored user_meta.
+	 * Clear any stored user_meta and retries
 	 *
 	 * Requires WordPress version 3.0.0, not used in previous versions
 	 */
@@ -184,9 +184,9 @@ class Cookies extends Plugin {
 			* get_option( 'hm_limit_login_allowed_lockouts' );
 
 		return array(
-			'retries'      => $retries,
-			'valid'        => $valid,
-			'retries_long' => $retries_long,
+			$retries,
+			$valid,
+			$retries_long,
 		);
 	}
 
@@ -291,9 +291,9 @@ class Cookies extends Plugin {
 		}
 
 		return array(
-			'lockouts' => $lockouts,
-			'retries'  => $retries,
-			'valid'    => $valid,
+			$lockouts,
+			$retries,
+			$valid,
 		);
 	}
 

--- a/inc/class-errors.php
+++ b/inc/class-errors.php
@@ -141,11 +141,16 @@ class Errors extends Plugin {
 			return false;
 		}
 
-		$action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : '';
+		$action     = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : '';
+		$logged_out = isset( $_REQUEST['loggedout'] );
 
-		return ( $action != 'lostpassword' && $action != 'retrievepassword'
-			&& $action != 'resetpass' && $action != 'rp'
-			&& $action != 'register' );
+		return ! $logged_out && ! in_array( $action, array(
+			'lostpassword',
+			'retrievepassword',
+			'resetpass',
+			'rp',
+			'register',
+		) );
 	}
 
 


### PR DESCRIPTION
Steps to reproduce bug with previous version:
1. Visit login screen, instantly presented with "too many login attempts" error despite not having attempted once.

With this branch:
1. Attempt to login as normal with a bad password, should see "X login attempts remaining"
2. Further login attempts with a bad password should show the number decrease until you are locked out for X minutes
3. A successful login with X attempts remaining should reset the lockouts and attempts remaining
