### PR TITLE
Add composer.json and update for Altis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jazzsequence/hm-limit-login-attempts",
+    "name": "humanmade/hm-limit-login-attempts",
     "description": "The original Limit Login Attempts plugin with the option to limit via username as well.",
     "type": "package",
     "license": "GPL-3.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jazzsequence/hm-limit-login-attempts",
     "description": "The original Limit Login Attempts plugin with the option to limit via username as well.",
-    "type": "wordpress-plugin",
+    "type": "package",
     "license": "GPL-3.0-or-later",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "humanmade/hm-limit-login-attempts",
+    "name": "jazzsequence/hm-limit-login-attempts",
     "description": "The original Limit Login Attempts plugin with the option to limit via username as well.",
     "type": "wordpress-plugin",
     "license": "GPL-3.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "humanmade/hm-limit-login-attempts",
+    "description": "The original Limit Login Attempts plugin with the option to limit via username as well.",
+    "type": "wordpress-plugin",
+    "license": "GPL-3.0-or-later",
+    "authors": [
+        {
+            "name": "Human Made",
+            "email": "hello@humanmade.com"
+        }
+    ],
+    "require": {}
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "humanmade/hm-limit-login-attempts",
     "description": "The original Limit Login Attempts plugin with the option to limit via username as well.",
-    "type": "package",
+    "type": "wordpress-plugin",
     "license": "GPL-3.0-or-later",
     "authors": [
         {
@@ -10,9 +10,6 @@
         }
     ],
     "autoload": {
-        "files": [
-            "hm-limit-login-attempts.php"
-        ],
         "classmap": [
             "inc/"
         ]

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,5 @@
             "name": "Human Made",
             "email": "hello@humanmade.com"
         }
-    ],
-    "autoload": {
-        "classmap": [
-            "inc/"
-        ]
-    }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,12 @@
             "email": "hello@humanmade.com"
         }
     ],
-    "require": {}
+    "autoload": {
+        "files": [
+            "hm-limit-login-attempts.php"
+        ],
+        "classmap": [
+            "inc/"
+        ]
+    }
 }

--- a/hm-limit-login-attempts.php
+++ b/hm-limit-login-attempts.php
@@ -29,7 +29,7 @@
 namespace HM\Limit_Login_Attempts;
 
 define('HM_LIMIT_LOGIN_VERSION', '1.0' );
-define('HM_LIMIT_LOGIN_DIR', trailingslashit( __DIR__ ) );
+define('HM_LIMIT_LOGIN_DIR', \trailingslashit( __DIR__ ) );
 
 /* Different ways to get remote address: direct & behind proxy */
 defined( 'HM_LIMIT_LOGIN_DIRECT_ADDR' ) or define( 'HM_LIMIT_LOGIN_DIRECT_ADDR', 'REMOTE_ADDR' );

--- a/hm-limit-login-attempts.php
+++ b/hm-limit-login-attempts.php
@@ -29,7 +29,7 @@
 namespace HM\Limit_Login_Attempts;
 
 define('HM_LIMIT_LOGIN_VERSION', '1.0' );
-define('HM_LIMIT_LOGIN_DIR', \trailingslashit( __DIR__ ) );
+define('HM_LIMIT_LOGIN_DIR', __DIR__ . '/' );
 
 /* Different ways to get remote address: direct & behind proxy */
 defined( 'HM_LIMIT_LOGIN_DIRECT_ADDR' ) or define( 'HM_LIMIT_LOGIN_DIRECT_ADDR', 'REMOTE_ADDR' );

--- a/hm-limit-login-attempts.php
+++ b/hm-limit-login-attempts.php
@@ -7,7 +7,7 @@
  * Author:       Human Made
  * Author URI:   http://hmn.md
  * Text Domain:  hm-limit-login-attempts
- * Version: 1.0
+ * Version: 1.1
  *
  *
  * Licenced under the GNU GPL:
@@ -28,7 +28,7 @@
 
 namespace HM\Limit_Login_Attempts;
 
-define('HM_LIMIT_LOGIN_VERSION', '1.0' );
+define('HM_LIMIT_LOGIN_VERSION', '1.1' );
 define('HM_LIMIT_LOGIN_DIR', __DIR__ . '/' );
 
 /* Different ways to get remote address: direct & behind proxy */

--- a/inc/class-options.php
+++ b/inc/class-options.php
@@ -19,7 +19,7 @@ class Options extends Plugin {
 	 */
 	public function admin_menu() {
 
-		add_options_page( 'HM Limit Login Attempts', 'HM Limit Login', 'manage_options', 'hm-limit-login-attempts', array( $this, 'option_page' ) );
+		add_options_page( __( 'Limit Login Attempts', 'limit-login-attempts' ), __( 'Limit Login', 'limit-login-attempts' ), 'manage_options', 'hm-limit-login-attempts', array( $this, 'option_page' ) );
 
 	}
 

--- a/inc/class-options.php
+++ b/inc/class-options.php
@@ -19,7 +19,7 @@ class Options extends Plugin {
 	 */
 	public function admin_menu() {
 
-		add_options_page( __( 'Limit Login Attempts', 'limit-login-attempts' ), __( 'Limit Login', 'limit-login-attempts' ), 'manage_options', 'hm-limit-login-attempts', array( $this, 'option_page' ) );
+		add_options_page( __( 'Limit Login Attempts', 'limit-login-attempts' ), __( 'Limit Logins', 'limit-login-attempts' ), 'manage_options', 'hm-limit-login-attempts', array( $this, 'option_page' ) );
 
 	}
 


### PR DESCRIPTION
For https://github.com/humanmade/altis-security/issues/28, a couple things needed to be done before the plugin would work in an Altis environment. This PR accomplishes _most_ of those.

* adds a `composer.json` file
* removes the "HM" from the menu name
* properly i18nizes the menu names
* removes the dependency on `trailingslashit` which isn't available when the plugin is loaded inside Altis.

**Note:** This plugin would still need to be added to Packagist but I do not have access to the company Packagist profile so I can't publish it.